### PR TITLE
fix: Custom Roles Not Having Custom Role In Spawned Event

### DIFF
--- a/EXILED/Exiled.CustomRoles/API/Features/CustomRole.cs
+++ b/EXILED/Exiled.CustomRoles/API/Features/CustomRole.cs
@@ -505,6 +505,7 @@ namespace Exiled.CustomRoles.API.Features
         public virtual void AddRole(Player player)
         {
             Log.Debug($"{Name}: Adding role to {player.Nickname}.");
+            TrackedPlayers.Add(player);
             player.UniqueRole = Name;
 
             if (Role != RoleTypeId.None)
@@ -526,7 +527,6 @@ namespace Exiled.CustomRoles.API.Features
             }
 
             player.UniqueRole = Name;
-            TrackedPlayers.Add(player);
 
             Timing.CallDelayed(
                 AddRoleDelay,


### PR DESCRIPTION
## Description
**Describe the changes** 
Changed back where the player is added to tracked players to where it was before a breaking change that shouldn't have happened. It is now before the role is set.

**What is the current behavior?** (You can also link to an open issue here)
The tracked players is added after the role is set. This was a breaking change added at a time where breaking changes were not allowed.

**What is the new behavior?** (if this is a feature change)
It is back to normal. Player is added to tracked players before the role is set.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

**Other information**:
N/A

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [x] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
