### PR TITLE
refactor: Individualized names to avoid duplication of AttackingEventArgs between Scp049 and Scp106

### DIFF
--- a/EXILED/Exiled.Events/EventArgs/Scp049/CardiacAttackingEventArgs.cs
+++ b/EXILED/Exiled.Events/EventArgs/Scp049/CardiacAttackingEventArgs.cs
@@ -1,45 +1,45 @@
 // -----------------------------------------------------------------------
-// <copyright file="AttackingEventArgs.cs" company="ExMod Team">
+// <copyright file="CardiacAttackingEventArgs.cs" company="ExMod Team">
 // Copyright (c) ExMod Team. All rights reserved.
 // Licensed under the CC BY-SA 3.0 license.
 // </copyright>
 // -----------------------------------------------------------------------
 
-namespace Exiled.Events.EventArgs.Scp106
+namespace Exiled.Events.EventArgs.Scp049
 {
     using Exiled.API.Features;
     using Exiled.API.Features.Roles;
     using Exiled.Events.EventArgs.Interfaces;
 
     /// <summary>
-    /// Contains all information before SCP-106 attacks a player.
+    /// Contains all information before SCP-049 attacks a player.
     /// </summary>
-    public class AttackingEventArgs : IScp106Event, IDeniableEvent
+    public class CardiacAttackingEventArgs : IScp049Event, IDeniableEvent
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="AttackingEventArgs"/> class.
+        /// Initializes a new instance of the <see cref="CardiacAttackingEventArgs"/> class.
         /// </summary>
         /// <param name="player"><inheritdoc cref="Player"/></param>
         /// <param name="target"><inheritdoc cref="Target"/></param>
         /// <param name="isAllowed"><inheritdoc cref="IsAllowed"/></param>
-        public AttackingEventArgs(Player player, Player target, bool isAllowed = true)
+        public CardiacAttackingEventArgs(Player player, Player target, bool isAllowed = true)
         {
             Player = player;
-            Scp106 = player.Role.As<Scp106Role>();
+            Scp049 = player.Role.As<Scp049Role>();
             Target = target;
             IsAllowed = isAllowed;
         }
 
+        /// <inheritdoc/>
+        public Scp049Role Scp049 { get; }
+
         /// <summary>
-        /// Gets the player controlling SCP-106.
+        /// Gets the player controlling SCP-049.
         /// </summary>
         public Player Player { get; }
 
-        /// <inheritdoc/>
-        public Scp106Role Scp106 { get; }
-
         /// <summary>
-        /// Gets the target of the attack.
+        /// Gets the target of attack.
         /// </summary>
         public Player Target { get; }
 

--- a/EXILED/Exiled.Events/EventArgs/Scp049/CardiacAttackingEventArgs.cs
+++ b/EXILED/Exiled.Events/EventArgs/Scp049/CardiacAttackingEventArgs.cs
@@ -1,5 +1,5 @@
 // -----------------------------------------------------------------------
-// <copyright file="CardiacAttackingEventArgs.cs" company="ExMod Team">
+// <copyright file="CardiacAttacking안녕하세요EventArgs.cs" company="ExMod Team">
 // Copyright (c) ExMod Team. All rights reserved.
 // Licensed under the CC BY-SA 3.0 license.
 // </copyright>

--- a/EXILED/Exiled.Events/EventArgs/Scp049/CardiacAttackingEventArgs.cs
+++ b/EXILED/Exiled.Events/EventArgs/Scp049/CardiacAttackingEventArgs.cs
@@ -1,5 +1,5 @@
 // -----------------------------------------------------------------------
-// <copyright file="CardiacAttacking안녕하세요EventArgs.cs" company="ExMod Team">
+// <copyright file="CardiacAttackingEventArgs.cs" company="ExMod Team">
 // Copyright (c) ExMod Team. All rights reserved.
 // Licensed under the CC BY-SA 3.0 license.
 // </copyright>

--- a/EXILED/Exiled.Events/EventArgs/Scp106/CapturingEventArgs.cs
+++ b/EXILED/Exiled.Events/EventArgs/Scp106/CapturingEventArgs.cs
@@ -1,45 +1,45 @@
 // -----------------------------------------------------------------------
-// <copyright file="AttackingEventArgs.cs" company="ExMod Team">
+// <copyright file="CapturingEventArgs.cs" company="ExMod Team">
 // Copyright (c) ExMod Team. All rights reserved.
 // Licensed under the CC BY-SA 3.0 license.
 // </copyright>
 // -----------------------------------------------------------------------
 
-namespace Exiled.Events.EventArgs.Scp049
+namespace Exiled.Events.EventArgs.Scp106
 {
     using Exiled.API.Features;
     using Exiled.API.Features.Roles;
     using Exiled.Events.EventArgs.Interfaces;
 
     /// <summary>
-    /// Contains all information before SCP-049 attacks a player.
+    /// Contains all information before SCP-106 attacks a player.
     /// </summary>
-    public class AttackingEventArgs : IScp049Event, IDeniableEvent
+    public class CapturingEventArgs : IScp106Event, IDeniableEvent
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="AttackingEventArgs"/> class.
+        /// Initializes a new instance of the <see cref="CapturingEventArgs"/> class.
         /// </summary>
         /// <param name="player"><inheritdoc cref="Player"/></param>
         /// <param name="target"><inheritdoc cref="Target"/></param>
         /// <param name="isAllowed"><inheritdoc cref="IsAllowed"/></param>
-        public AttackingEventArgs(Player player, Player target, bool isAllowed = true)
+        public CapturingEventArgs(Player player, Player target, bool isAllowed = true)
         {
             Player = player;
-            Scp049 = player.Role.As<Scp049Role>();
+            Scp106 = player.Role.As<Scp106Role>();
             Target = target;
             IsAllowed = isAllowed;
         }
 
-        /// <inheritdoc/>
-        public Scp049Role Scp049 { get; }
-
         /// <summary>
-        /// Gets the player controlling SCP-049.
+        /// Gets the player controlling SCP-106.
         /// </summary>
         public Player Player { get; }
 
+        /// <inheritdoc/>
+        public Scp106Role Scp106 { get; }
+
         /// <summary>
-        /// Gets the target of attack.
+        /// Gets the target of the attack.
         /// </summary>
         public Player Target { get; }
 

--- a/EXILED/Exiled.Events/Handlers/Scp049.cs
+++ b/EXILED/Exiled.Events/Handlers/Scp049.cs
@@ -40,7 +40,7 @@ namespace Exiled.Events.Handlers
         /// <summary>
         /// Invoked before SCP-049 attacks player.
         /// </summary>
-        public static Event<AttackingEventArgs> Attacking { get; set; } = new();
+        public static Event<CardiacAttackingEventArgs> Attacking { get; set; } = new();
 
         /// <summary>
         /// Called before SCP-049 finishes reviving a player.
@@ -69,7 +69,7 @@ namespace Exiled.Events.Handlers
         /// <summary>
         /// Called before SCP-049 attacks player.
         /// </summary>
-        /// <param name="ev">The <see cref="AttackingEventArgs"/> instance.</param>
-        public static void OnAttacking(AttackingEventArgs ev) => Attacking.InvokeSafely(ev);
+        /// <param name="ev">The <see cref="CardiacAttackingEventArgs"/> instance.</param>
+        public static void OnAttacking(CardiacAttackingEventArgs ev) => Attacking.InvokeSafely(ev);
     }
 }

--- a/EXILED/Exiled.Events/Handlers/Scp106.cs
+++ b/EXILED/Exiled.Events/Handlers/Scp106.cs
@@ -20,7 +20,7 @@ namespace Exiled.Events.Handlers
         /// <summary>
         /// Invoked before SCP-106 attacks player.
         /// </summary>
-        public static Event<AttackingEventArgs> Attacking { get; set; } = new();
+        public static Event<CapturingEventArgs> Attacking { get; set; } = new();
 
         /// <summary>
         /// Invoked before SCP-106 teleports using the hunter atlas.
@@ -40,8 +40,8 @@ namespace Exiled.Events.Handlers
         /// <summary>
         /// Called before SCP-106 attacks player.
         /// </summary>
-        /// <param name="ev">The <see cref="AttackingEventArgs" /> instance.</param>
-        public static void OnAttacking(AttackingEventArgs ev) => Attacking.InvokeSafely(ev);
+        /// <param name="ev">The <see cref="CapturingEventArgs" /> instance.</param>
+        public static void OnAttacking(CapturingEventArgs ev) => Attacking.InvokeSafely(ev);
 
         /// <summary>
         /// Called before SCP-106 teleports using the hunter atlas.

--- a/EXILED/Exiled.Events/Patches/Events/Scp049/Attacking.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Scp049/Attacking.cs
@@ -55,7 +55,7 @@ namespace Exiled.Events.Patches.Events.Scp049
                     new(OpCodes.Ldc_I4_1),
 
                     // AttackingEventArgs ev = new(player, target, true);
-                    new(OpCodes.Newobj, GetDeclaredConstructors(typeof(AttackingEventArgs))[0]),
+                    new(OpCodes.Newobj, GetDeclaredConstructors(typeof(CardiacAttackingEventArgs))[0]),
                     new(OpCodes.Dup),
 
                     // Handlers.Scp049.OnAttacking(ev);
@@ -63,7 +63,7 @@ namespace Exiled.Events.Patches.Events.Scp049
 
                     // if (!ev.IsAllowed)
                     //      return;
-                    new(OpCodes.Callvirt, PropertyGetter(typeof(AttackingEventArgs), nameof(AttackingEventArgs.IsAllowed))),
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(CardiacAttackingEventArgs), nameof(CardiacAttackingEventArgs.IsAllowed))),
                     new(OpCodes.Brtrue_S, continueLabel),
 
                     new(OpCodes.Ret),

--- a/EXILED/Exiled.Events/Patches/Events/Scp106/Attacking.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Scp106/Attacking.cs
@@ -54,7 +54,7 @@ namespace Exiled.Events.Patches.Events.Scp106
                     new(OpCodes.Ldc_I4_1),
 
                     // AttackingEventArgs ev = new(player, target, true);
-                    new(OpCodes.Newobj, GetDeclaredConstructors(typeof(AttackingEventArgs))[0]),
+                    new(OpCodes.Newobj, GetDeclaredConstructors(typeof(CapturingEventArgs))[0]),
                     new(OpCodes.Dup),
 
                     // Handlers.Scp106.OnAttacking(ev);
@@ -62,7 +62,7 @@ namespace Exiled.Events.Patches.Events.Scp106
 
                     // if (!ev.IsAllowed)
                     //      return;
-                    new(OpCodes.Callvirt, PropertyGetter(typeof(AttackingEventArgs), nameof(AttackingEventArgs.IsAllowed))),
+                    new(OpCodes.Callvirt, PropertyGetter(typeof(CapturingEventArgs), nameof(CapturingEventArgs.IsAllowed))),
                     new(OpCodes.Brfalse_S, ret),
                 });
             newInstructions[newInstructions.Count - 1].labels.Add(ret);


### PR DESCRIPTION
## Description
**Describe the changes** 
This PR rename Scp049 and Scp106 to their attack skill names as published in the official SCP: Secret Laboratory documentation.
https://en.scpslgame.com/index.php?title=SCPs

**What is the current behavior?** (You can also link to an open issue here)
Existing Scp049 and Scp106 classes had duplicate EventArgs names. 

**What is the new behavior?** (if this is a feature change)
Scp049 - AttackingEventArgs ⏩ CardiacAttackingEventArgs
Scp106 - AttackingEventArgs ⏩ CapturingEventArgs

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
yes, people who use AttackingEventArgs need to change class name

**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [x] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
