### PR TITLE
feat: Add Capybara::Create and Text::Create

### DIFF
--- a/EXILED/Exiled.API/Features/Toys/AdminToy.cs
+++ b/EXILED/Exiled.API/Features/Toys/AdminToy.cs
@@ -181,25 +181,6 @@ namespace Exiled.API.Features.Toys
             where T : AdminToy => Get(adminToyBase) as T;
 
         /// <summary>
-        /// Spawns the toy into the game. Use <see cref="UnSpawn"/> to remove it.
-        /// </summary>
-        public void Spawn() => NetworkServer.Spawn(AdminToyBase.gameObject);
-
-        /// <summary>
-        /// Removes the toy from the game. Use <see cref="Spawn"/> to bring it back.
-        /// </summary>
-        public void UnSpawn() => NetworkServer.UnSpawn(AdminToyBase.gameObject);
-
-        /// <summary>
-        /// Destroys the toy.
-        /// </summary>
-        public void Destroy()
-        {
-            BaseToAdminToy.Remove(AdminToyBase);
-            NetworkServer.Destroy(AdminToyBase.gameObject);
-        }
-
-        /// <summary>
         /// Creates a new <see cref="AdminToy"/>.
         /// </summary>
         /// <param name="position"> The position of the <see cref="AdminToy"/>.</param>
@@ -243,6 +224,25 @@ namespace Exiled.API.Features.Toys
                 NetworkServer.Spawn(t2.gameObject);
 
             return Get(t2);
+        }
+
+        /// <summary>
+        /// Spawns the toy into the game. Use <see cref="UnSpawn"/> to remove it.
+        /// </summary>
+        public void Spawn() => NetworkServer.Spawn(AdminToyBase.gameObject);
+
+        /// <summary>
+        /// Removes the toy from the game. Use <see cref="Spawn"/> to bring it back.
+        /// </summary>
+        public void UnSpawn() => NetworkServer.UnSpawn(AdminToyBase.gameObject);
+
+        /// <summary>
+        /// Destroys the toy.
+        /// </summary>
+        public void Destroy()
+        {
+            BaseToAdminToy.Remove(AdminToyBase);
+            NetworkServer.Destroy(AdminToyBase.gameObject);
         }
 
         private static class PrefabCache<T>

--- a/EXILED/Exiled.API/Features/Toys/AdminToy.cs
+++ b/EXILED/Exiled.API/Features/Toys/AdminToy.cs
@@ -209,7 +209,7 @@ namespace Exiled.API.Features.Toys
         /// <typeparam name="T"> The specific type of <see cref="AdminToyBase"/> to instantiate (e.g., <see cref="CapybaraToy"/>, <see cref="TextToy"/>).</typeparam>
         /// <returns> The new <see cref="AdminToy"/>.</returns>
         /// <exception cref="InvalidOperationException"> Thrown if no prefab with a <typeparamref name="T"/> component exists in <see cref="NetworkClient.prefabs"/>.</exception>
-        public virtual AdminToy Create<T>(Vector3? position, Vector3? rotation, Vector3? scale, bool spawn)
+        public static AdminToy Create<T>(Vector3? position, Vector3? rotation, Vector3? scale, bool spawn)
             where T : AdminToyBase
         {
             if (PrefabCache<T>.Prefab == null)

--- a/EXILED/Exiled.API/Features/Toys/Capybara.cs
+++ b/EXILED/Exiled.API/Features/Toys/Capybara.cs
@@ -9,7 +9,9 @@ namespace Exiled.API.Features.Toys
 {
     using AdminToys;
     using Enums;
-    using Exiled.API.Interfaces;
+    using Interfaces;
+    using Mirror;
+    using UnityEngine;
 
     /// <summary>
     /// A wrapper class for <see cref="CapybaraToy"/>.
@@ -19,9 +21,9 @@ namespace Exiled.API.Features.Toys
         /// <summary>
         /// Initializes a new instance of the <see cref="Capybara"/> class.
         /// </summary>
-        /// <param name="speakerToy">The <see cref="CapybaraToy"/> of the toy.</param>
-        internal Capybara(CapybaraToy speakerToy)
-            : base(speakerToy, AdminToyType.Speaker) => Base = speakerToy;
+        /// <param name="capybaraToy">The <see cref="CapybaraToy"/> of the toy.</param>
+        internal Capybara(CapybaraToy capybaraToy)
+            : base(capybaraToy, AdminToyType.Capybara) => Base = capybaraToy;
 
         /// <summary>
         /// Gets the prefab.
@@ -34,12 +36,33 @@ namespace Exiled.API.Features.Toys
         public CapybaraToy Base { get; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the capybara can be collided with.
+        /// Gets or sets a value indicating whether the capybara can be collided with. Only server side.
         /// </summary>
         public bool Collidable
         {
-            get => Base.Network_collisionsEnabled;
-            set => Base.Network_collisionsEnabled = value;
+            get => Base.CollisionsEnabled;
+            set => Base.CollisionsEnabled = value;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Capybara"/>.
+        /// </summary>
+        /// <param name="posititon"> The position of the <see cref="Capybara"/>.</param>
+        /// <param name="rotation"> The rotation of the <see cref="Capybara"/>.</param>
+        /// <param name="scale"> The scale of the <see cref="Capybara"/>.</param>
+        /// <param name="spawn"> Whether the <see cref="Capybara"/> should be initially spawned.</param>
+        /// <returns> The new <see cref="Capybara"/>.</returns>
+        public static Capybara Create(Vector3? posititon, Vector3? rotation, Vector3? scale, bool spawn)
+        {
+            Capybara capybara = new Capybara(Object.Instantiate(Prefab));
+            capybara.Position = posititon ?? Vector3.zero;
+            capybara.Rotation = Quaternion.Euler(rotation ?? Vector3.zero);
+            capybara.Scale = scale ?? Vector3.one;
+
+            if (spawn)
+                capybara.Spawn();
+
+            return capybara;
         }
     }
 }

--- a/EXILED/Exiled.API/Features/Toys/Text.cs
+++ b/EXILED/Exiled.API/Features/Toys/Text.cs
@@ -5,7 +5,6 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
-#nullable enable
 namespace Exiled.API.Features.Toys
 {
     using AdminToys;
@@ -63,7 +62,7 @@ namespace Exiled.API.Features.Toys
         /// <param name="scale"> The scale of the <see cref="Text"/>.</param>
         /// <param name="spawn"> Whether the <see cref="Text"/> should be initially spawned.</param>
         /// <returns> The new <see cref="Text"/>.</returns>
-        public static Text Create(string? newText, Vector2? displaySize, Vector3? posititon, Vector3? rotation, Vector3? scale, bool spawn)
+        public static Text Create(string newText, Vector2? displaySize, Vector3? posititon, Vector3? rotation, Vector3? scale, bool spawn)
         {
             Text text = new Text(Object.Instantiate(Prefab));
             text.Position = posititon ?? Vector3.zero;

--- a/EXILED/Exiled.API/Features/Toys/Text.cs
+++ b/EXILED/Exiled.API/Features/Toys/Text.cs
@@ -5,11 +5,12 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
+#nullable enable
 namespace Exiled.API.Features.Toys
 {
     using AdminToys;
     using Enums;
-    using Exiled.API.Interfaces;
+    using Interfaces;
     using UnityEngine;
 
     /// <summary>
@@ -20,9 +21,9 @@ namespace Exiled.API.Features.Toys
         /// <summary>
         /// Initializes a new instance of the <see cref="Text"/> class.
         /// </summary>
-        /// <param name="speakerToy">The <see cref="TextToy"/> of the toy.</param>
-        internal Text(TextToy speakerToy)
-            : base(speakerToy, AdminToyType.TextToy) => Base = speakerToy;
+        /// <param name="textToy">The <see cref="TextToy"/> of the toy.</param>
+        internal Text(TextToy textToy)
+            : base(textToy, AdminToyType.TextToy) => Base = textToy;
 
         /// <summary>
         /// Gets the prefab.
@@ -50,6 +51,31 @@ namespace Exiled.API.Features.Toys
         {
             get => Base.Network_displaySize;
             set => Base.Network_displaySize = value;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Text"/>.
+        /// </summary>
+        /// <param name="newText"> The text to shown <see cref="TextFormat"/>.</param>
+        /// <param name="displaySize"> The size of the <see cref="DisplaySize"/>.</param>
+        /// <param name="posititon"> The position of the <see cref="Text"/>.</param>
+        /// <param name="rotation"> The rotation of the <see cref="Text"/>.</param>
+        /// <param name="scale"> The scale of the <see cref="Text"/>.</param>
+        /// <param name="spawn"> Whether the <see cref="Text"/> should be initially spawned.</param>
+        /// <returns> The new <see cref="Text"/>.</returns>
+        public static Text Create(string? newText, Vector2? displaySize, Vector3? posititon, Vector3? rotation, Vector3? scale, bool spawn)
+        {
+            Text text = new Text(Object.Instantiate(Prefab));
+            text.Position = posititon ?? Vector3.zero;
+            text.Rotation = Quaternion.Euler(rotation ?? Vector3.zero);
+            text.Scale = scale ?? Vector3.one;
+
+            text.TextFormat = newText ?? string.Empty;
+            text.DisplaySize = displaySize ?? TextToy.DefaultDisplaySize;
+
+            if (spawn)
+                text.Spawn();
+            return text;
         }
     }
 }


### PR DESCRIPTION
## Description
**Describe the changes** 

In Text.cs change of Network_collisionsEnabled to CollisionsEnabled.

Change to param name for Capybara.cs and Text.cs because he was speakerToy.

**What is the current behavior?** (You can also link to an open issue here)

Name of Network_collisionsEnabled in Text.cs.
Capybara.cs and Text.cs use speakerToy parameters.

**What is the new behavior?** (if this is a feature change)
- Add Capybara::Create and Text::Create
- Change Network_collisionsEnabled to CollisionsEnabled in Text.cs
- Name of parameters change.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no

**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
