### PR TITLE
feat: Add event OnJailbirdChargeComplete and fix ChargingJailbird docs

### DIFF
--- a/EXILED/Exiled.Events/EventArgs/Item/ChargingJailbirdEventArgs.cs
+++ b/EXILED/Exiled.Events/EventArgs/Item/ChargingJailbirdEventArgs.cs
@@ -12,20 +12,20 @@ namespace Exiled.Events.EventArgs.Item
     using Exiled.Events.EventArgs.Interfaces;
 
     /// <summary>
-    /// Contains all information before a player charges a <see cref="Jailbird"/>.
+    /// Contains all information before a player starts charging an <see cref="Jailbird"/>.
     /// </summary>
-    public class ChargingJailbirdEventArgs : IItemEvent
+    public class ChargingJailbirdEventArgs : IItemEvent, IDeniableEvent
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ChargingJailbirdEventArgs"/> class.
         /// </summary>
-        /// <param name="player"><inheritdoc cref="Player"/></param>
-        /// <param name="swingItem">The item being charged.</param>
-        /// <param name="isAllowed">Whether the item can be charged.</param>
-        public ChargingJailbirdEventArgs(ReferenceHub player, InventorySystem.Items.ItemBase swingItem, bool isAllowed = true)
+        /// <param name="player">The player who is attempting to charge the Jailbird.</param>
+        /// <param name="jailbird">The jailbird being charged.</param>
+        /// <param name="isAllowed">Whether the item is allowed to be charged.</param>
+        public ChargingJailbirdEventArgs(ReferenceHub player, InventorySystem.Items.ItemBase jailbird, bool isAllowed = true)
         {
             Player = Player.Get(player);
-            Jailbird = (Jailbird)Item.Get(swingItem);
+            Jailbird = Item.Get<Jailbird>(jailbird);
             IsAllowed = isAllowed;
         }
 

--- a/EXILED/Exiled.Events/EventArgs/Item/JailbirdChargeCompleteEventArgs.cs
+++ b/EXILED/Exiled.Events/EventArgs/Item/JailbirdChargeCompleteEventArgs.cs
@@ -1,0 +1,52 @@
+// -----------------------------------------------------------------------
+// <copyright file="JailbirdChargeCompleteEventArgs.cs" company="ExMod Team">
+// Copyright (c) ExMod Team. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Exiled.Events.EventArgs.Item
+{
+    using Exiled.API.Features;
+    using Exiled.API.Features.Items;
+    using Exiled.Events.EventArgs.Interfaces;
+
+    /// <summary>
+    /// Contains all information when a player completes charging a <see cref="Jailbird"/>.
+    /// </summary>
+    public class JailbirdChargeCompleteEventArgs : IItemEvent, IDeniableEvent
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JailbirdChargeCompleteEventArgs"/> class.
+        /// </summary>
+        /// <param name="player">The player who completed the charge.</param>
+        /// <param name="jailbird">The Jailbird item whose charge is complete.</param>
+        /// <param name="isAllowed">Whether the Jailbird is allowed to attack after charging.</param>
+        public JailbirdChargeCompleteEventArgs(ReferenceHub player, InventorySystem.Items.ItemBase jailbird, bool isAllowed = true)
+        {
+            Player = Player.Get(player);
+            Jailbird = Item.Get<Jailbird>(jailbird);
+            IsAllowed = isAllowed;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="API.Features.Player"/> who completed the charge.
+        /// </summary>
+        public Player Player { get; }
+
+        /// <summary>
+        /// Gets the <see cref="API.Features.Items.Jailbird"/> that was fully charged.
+        /// </summary>
+        public Jailbird Jailbird { get; }
+
+        /// <summary>
+        /// Gets the <see cref="API.Features.Items.Item"/> associated with the charged Jailbird.
+        /// </summary>
+        public Item Item => Jailbird;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the Jailbird is allowed to attack after charging.
+        /// </summary>
+        public bool IsAllowed { get; set; }
+    }
+}

--- a/EXILED/Exiled.Events/Handlers/Item.cs
+++ b/EXILED/Exiled.Events/Handlers/Item.cs
@@ -44,9 +44,14 @@ namespace Exiled.Events.Handlers
         public static Event<SwingingEventArgs> Swinging { get; set; } = new();
 
         /// <summary>
-        /// Invoked before a <see cref="API.Features.Items.Jailbird"/> is charged.
+        /// Invoked when a <see cref="API.Features.Items.Jailbird"/> starts charging.
         /// </summary>
         public static Event<ChargingJailbirdEventArgs> ChargingJailbird { get; set; } = new();
+
+        /// <summary>
+        /// Invoked after a <see cref="API.Features.Items.Jailbird"/> finishes charging.
+        /// </summary>
+        public static Event<JailbirdChargeCompleteEventArgs> JailbirdChargeComplete { get; set; } = new();
 
         /// <summary>
         /// Invoked before a radio pickup is draining battery.
@@ -102,10 +107,16 @@ namespace Exiled.Events.Handlers
         public static void OnSwinging(SwingingEventArgs ev) => Swinging.InvokeSafely(ev);
 
         /// <summary>
-        /// Called before a <see cref="API.Features.Items.Jailbird"/> is charged.
+        /// Called before a <see cref="API.Features.Items.Jailbird"/> that is being charged.
         /// </summary>
         /// <param name="ev">The <see cref="ChargingJailbirdEventArgs"/> instance.</param>
         public static void OnChargingJailbird(ChargingJailbirdEventArgs ev) => ChargingJailbird.InvokeSafely(ev);
+
+        /// <summary>
+        /// Called after a <see cref="API.Features.Items.Jailbird"/> finish charging.
+        /// </summary>
+        /// <param name="ev">The <see cref="ChargingJailbirdEventArgs"/> instance.</param>
+        public static void OnJailbirdChargeComplete(JailbirdChargeCompleteEventArgs ev) => JailbirdChargeComplete.InvokeSafely(ev);
 
         /// <summary>
         /// Called before radio pickup is draining battery.

--- a/EXILED/Exiled.Events/Patches/Events/Item/JailbirdPatch.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Item/JailbirdPatch.cs
@@ -92,7 +92,8 @@ namespace Exiled.Events.Patches.Events.Item
                     if (ev.IsAllowed)
                         return true;
 
-                    instance.SendRpc(JailbirdMessageType.ChargeFailed);
+                    ev.Player.RemoveHeldItem(destroy: false);
+                    ev.Player.CurrentItem = ev.Item;
                     return false;
                 }
 

--- a/EXILED/Exiled.Events/Patches/Events/Item/JailbirdPatch.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Item/JailbirdPatch.cs
@@ -83,11 +83,23 @@ namespace Exiled.Events.Patches.Events.Item
                     return ev.IsAllowed;
                 }
 
-                case JailbirdMessageType.ChargeStarted:
+                case JailbirdMessageType.ChargeLoadTriggered:
                 {
                     ChargingJailbirdEventArgs ev = new(instance.Owner, instance);
 
                     Item.OnChargingJailbird(ev);
+                    if (ev.IsAllowed)
+                        return true;
+
+                    instance.SendRpc(JailbirdMessageType.ChargeFailed);
+                    return false;
+                }
+
+                case JailbirdMessageType.ChargeStarted:
+                {
+                    JailbirdChargeCompleteEventArgs ev = new(instance.Owner, instance);
+
+                    Item.OnJailbirdChargeComplete(ev);
                     if (ev.IsAllowed)
                         return true;
 

--- a/EXILED/Exiled.Events/Patches/Events/Item/JailbirdPatch.cs
+++ b/EXILED/Exiled.Events/Patches/Events/Item/JailbirdPatch.cs
@@ -27,6 +27,7 @@ namespace Exiled.Events.Patches.Events.Item
     /// </summary>
     [EventPatch(typeof(Item), nameof(Item.Swinging))]
     [EventPatch(typeof(Item), nameof(Item.ChargingJailbird))]
+    [EventPatch(typeof(Item), nameof(Item.JailbirdChargeComplete))]
     [HarmonyPatch(typeof(JailbirdItem), nameof(JailbirdItem.ServerProcessCmd))]
     internal static class JailbirdPatch
     {


### PR DESCRIPTION
## Description
**Describe the changes** 
🤗

**What is the current behavior?** (You can also link to an open issue here)
OnChargingJailbird is called after the jailbird is already charged and the player starts attacking. That is, after 3 seconds from the start of charging

**What is the new behavior?** (if this is a feature change)
Now OnChargingJailbird is called immediately when using Jailbird, and OnJailbirdChargeComplete is called after the end of charging (3 sec)

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Event OnChargingJailbird changed to OnJailbirdChargeComplete

**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [x] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing
