### PR TITLE
feat: SendConsoleMessage() has default value of color and size

### DIFF
--- a/EXILED/Exiled.API/Features/Player.cs
+++ b/EXILED/Exiled.API/Features/Player.cs
@@ -2047,7 +2047,7 @@ namespace Exiled.API.Features
         /// <param name="message">The message to send.</param>
         /// <param name="color">The color of the message.</param>
         /// <param name="size">The font size of the message. Default is 18.</param>
-        public void SendConsoleMessage(string message, string color = "white", int size = 18)
+        public void SendConsoleMessage(string message, string color = "white", int size = 25)
         {
             string[] lines = message.Split('\n');
 

--- a/EXILED/Exiled.API/Features/Player.cs
+++ b/EXILED/Exiled.API/Features/Player.cs
@@ -2042,11 +2042,25 @@ namespace Exiled.API.Features
         public bool RemoveHeldItem(bool destroy = true) => RemoveItem(CurrentItem, destroy);
 
         /// <summary>
-        /// Sends a console message to the player's console.
+        /// Sends a message to the player's console.
         /// </summary>
-        /// <param name="message">The message to be sent.</param>
-        /// <param name="color">The message color.</param>
-        public void SendConsoleMessage(string message, string color) => referenceHub.gameConsoleTransmission.SendToClient(message, color);
+        /// <param name="message">The message to send.</param>
+        /// <param name="color">The color of the message.</param>
+        /// <param name="size">The font size of the message. Default is 18.</param>
+        public void SendConsoleMessage(string message, string color = "white", int size = 18)
+        {
+            string[] lines = message.Split('\n');
+
+            for (int i = 0; i < lines.Length; i++)
+            {
+                if (!string.IsNullOrWhiteSpace(lines[i]))
+                    lines[i] = $"<size={size}>{lines[i]}</size>";
+            }
+
+            message = string.Join("\n", lines);
+
+            referenceHub.gameConsoleTransmission.SendToClient(message, color);
+        }
 
         /// <summary>
         /// Disconnects the player.


### PR DESCRIPTION
## Description
**Describe the changes** 
SendConsoleMessage() has default value of color and size

**What is the current behavior?** (You can also link to an open issue here)
SendConsoleMessage() has no any default value

**What is the new behavior?** (if this is a feature change)
default color is "white"
default size is 25

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
❌❌❌🏳️

**Other information**:

<br />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentations
<br />

## Submission checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] I have checked the project can be compiled
- [x] I have tested my changes and it worked as expected

### Patches (if there are any changes related to Harmony patches)
- [ ] I have checked no IL patching errors in the console

### Other
- [ ] Still requires more testing

![스크린샷 2025-05-23 161248](https://github.com/user-attachments/assets/67c5192d-9319-47fe-a801-6db22939e04b)
![스크린샷 2025-05-23 161406](https://github.com/user-attachments/assets/f64a0716-452c-4562-8f6e-550a36a3bf12)
