### PR TITLE
docs: Fix dead links in README

### DIFF
--- a/.github/documentation/README.md
+++ b/.github/documentation/README.md
@@ -11,17 +11,17 @@ Installation of EXILED is quite simple. It loads itself through Northwood’s Pl
 If you choose to use the installer it will, if run correctly, take care of installing all EXILED features.
 
 # Windows
-### Automatic installation ([more information](https://github.com/ExMod-Team/EXILED/blob/master/EXILED/Exiled.Installer/README.md))
+### Automatic installation ([more information](https://github.com/ExSLMod-Team/EXILED/blob/master/EXILED/Exiled.Installer/README.md))
 **Note**: Make sure you're on the user that runs the server, or you have Admin privileges before running the Installer.
 
-  - Download the **`Exiled.Installer-Win.exe` [from here](https://github.com/ExMod-Team/EXILED/releases)** (click on Assets -> click the Installer)
+  - Download the **`Exiled.Installer-Win.exe` [from here](https://github.com/ExSLMod-Team/EXILED/releases)** (click on Assets -> click the Installer)
   - Place it on your server folder (download the dedicated server if you haven't)
   - Double click the **`Exiled.Installer.exe`** or **[download this .bat](https://www.dropbox.com/scl/fi/7yh0r3q0vdn6ic4rhuu3l/install-prerelease.bat?rlkey=99fwjbwy1xg61qgtak0qzb9rd&st=8xs4xks8&dl=1)** and place it in the server folder to install the latest pre-release
   - To get and install plugins, check the [Installing plugins](#installing-plugins) section down below.
 **Note:** If you are installing EXILED on a remote server, make sure you run the .exe as the same user that runs your SCP:SL servers (or one with Admin privileges)
 
 ### Manual installation
-  - Download the **`Exiled.tar.gz` [from here](https://github.com/ExMod-Team/EXILED/releases)**
+  - Download the **`Exiled.tar.gz` [from here](https://github.com/ExSLMod-Team/EXILED/releases)**
   - Extract its contents with [7Zip](https://www.7-zip.org/) or [WinRar](https://www.win-rar.com/download.html?&L=6)
   - Move the **``EXILED``** folder to **`%appdata%`** *Note: This folder needs to go in ``C:\Users\%UserName%\AppData\Roaming``, and ***NOT*** ``C:\Users\%UserName%\AppData\Roaming\SCP Secret Laboratory``, and **IT MUST** be in (...)\AppData\Roaming, not (...)\AppData\!*
   - Move **``SCP Secret Laboratory``** to **`%appdata%`**.
@@ -37,11 +37,11 @@ That's it, EXILED should now be installed and active the next time you boot up y
   - Move it to: ``C:\Users\%UserName%\AppData\Roaming\EXILED\Plugins`` (move here by pressing Win + R, then writing `%appdata%`)
 
 # Linux
-### Automatic installation ([more information](https://github.com/ExMod-Team/EXILED/blob/master/EXILED/Exiled.Installer/README.md))
+### Automatic installation ([more information](https://github.com/ExSLMod-Team/EXILED/blob/master/EXILED/Exiled.Installer/README.md))
 
 **Note:** If you are installing EXILED on a remote server, make sure you run the Installer as the same user that runs your SCP:SL servers (or root)
 
-  - Download the **`Exiled.Installer-Linux` [from here](https://github.com/ExMod-Team/EXILED/releases)** (click on Assets -> download the Installer)
+  - Download the **`Exiled.Installer-Linux` [from here](https://github.com/ExSLMod-Team/EXILED/releases)** (click on Assets -> download the Installer)
   - Install it by either typing **`./Exiled.Installer-Linux --path /path/to/server`** or move it inside the server folder directly, move to it with the terminal (`cd`) and type: **`./Exiled.Installer-Linux`**.
   - If you want the latest pre-release, simply add **`--pre-releases`**. Example: **`./Exiled.Installer-Linux /home/scp/server --pre-releases`**
   - Another example, if you placed `Exiled.Installer-Linux` in your server folder: **`/home/scp/server/Exiled.Installer-Linux --pre-releases`**
@@ -49,7 +49,7 @@ That's it, EXILED should now be installed and active the next time you boot up y
 
 ### Manual installation
   - **Ensure** you are logged in on the user that runs the SCP servers.
-  - Download the **`Exiled.tar.gz` [from here](https://github.com/ExMod-Team/EXILED/releases)** (SSH: right click and to get the `Exiled.tar.gz` link, then type: **`wget (link_to_download)`**)
+  - Download the **`Exiled.tar.gz` [from here](https://github.com/ExSLMod-Team/EXILED/releases)** (SSH: right click and to get the `Exiled.tar.gz` link, then type: **`wget (link_to_download)`**)
   - To extract it to your current folder, type **``tar -xzvf EXILED.tar.gz``**
   - Move the **`EXILED`** folder to **``~/.config``**. *Note: This folder needs to go in ``~/.config``, and ***NOT*** ``~/.config/SCP Secret Laboratory``* (SSH: **`mv EXILED ~/.config/`**)
   - Move the **`SCP Secret Laboratory`** folder to **``~/.config``**. *Note: This folder needs to go in ``~/.config``, and ***NOT*** ``~/.config/SCP Secret Laboratory``* (SSH: **`mv SCP Secret Laboratory ~/.config/`**)
@@ -71,7 +71,7 @@ However, some plugins might get their config settings from other locations on th
 
 If you wish to make a plugin for EXILED, it's quite simple to do so. If you would like more of a tutorial please visit our [Getting Started Page.](GettingStarted.md).
 
-For more comprehensive and actively updated tutorials, see [the EXILED website](https://exmod-team.github.io/EXILED/).
+For more comprehensive and actively updated tutorials, see [the EXILED website](https://exslmod-team.github.io/EXILED/).
 
 But make sure to follow these rules when publishing your plugins:
 


### PR DESCRIPTION
Change all links with ExMod in them to ExSLMod to redirect to the new repo and github pages site